### PR TITLE
Adapt run script to antlr3 package change

### DIFF
--- a/utils/subscription-matcher
+++ b/utils/subscription-matcher
@@ -3,4 +3,11 @@
 EXTRA_ARGS=""
 java -version 2>&1 | grep IBM > /dev/null && { EXTRA_ARGS="-Xdump:heap:file=/var/crash/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd -Xdump:java:file=/var/crash/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt -Xdump:snap:file=/var/crash/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc -Xdump:system:file=/var/crash/core.%Y%m%d.%H%M%S.%pid.%seq.dmp"; }
 
-exec java -cp $(build-classpath antlr-runtime-3 commons-io commons-lang commons-lang3 commons-math3 commons-cli commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal kie-soup-commons kie-soup-project-datamodel-commons kie-soup-maven-support log4j12/log4j-12 mvel2 optaplanner-core slf4j/api slf4j/log4j12 xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G ${EXTRA_ARGS} com.suse.matcher.Main "$@"
+# Verify the correct name of the antlr jar (it depends on the package providing it)
+if build-classpath antlr3-runtime >/dev/null 2>&1; then
+    ANTLR=antlr3-runtime
+else
+    ANTLR=antlr-runtime-3
+fi
+
+exec java -cp $(build-classpath $ANTLR commons-io commons-lang commons-lang3 commons-math3 commons-cli commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal kie-soup-commons kie-soup-project-datamodel-commons kie-soup-maven-support log4j12/log4j-12 mvel2 optaplanner-core slf4j/api slf4j/log4j12 xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G ${EXTRA_ARGS} com.suse.matcher.Main "$@"


### PR DESCRIPTION
The implementation of [this ticket](https://github.com/SUSE/spacewalk/issues/16933) led to the change of the package providing `antlr`. The new package, while containing the same version and code of the previous one, has a different naming format for the jar itself. This PR adapts the Bash script `utils/subscription-matcher` and make it able to run with any of the two packages.