### PR TITLE
change classpath for commons-csv and commons-math3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.2</version>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 </project>

--- a/utils/subscription-matcher
+++ b/utils/subscription-matcher
@@ -10,4 +10,4 @@ else
     ANTLR=antlr-runtime-3
 fi
 
-exec java -cp $(build-classpath $ANTLR commons-io commons-lang commons-lang3 commons-math3 commons-cli commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal kie-soup-commons kie-soup-project-datamodel-commons kie-soup-maven-support log4j/log4j-api log4j/log4j-core log4j/log4j-slf4j-impl mvel2 optaplanner-core slf4j/api xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G ${EXTRA_ARGS} com.suse.matcher.Main "$@"
+exec java -cp $(build-classpath $ANTLR commons-io commons-lang commons-lang3 apache-commons-math/commons-math3 commons-cli apache-commons-csv/commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal kie-soup-commons kie-soup-project-datamodel-commons kie-soup-maven-support log4j/log4j-api log4j/log4j-core log4j/log4j-slf4j-impl mvel2 optaplanner-core slf4j/api xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G ${EXTRA_ARGS} com.suse.matcher.Main "$@"


### PR DESCRIPTION
I try to use newer version of apache-commons-csv and apache-commons-math3 build with xmvn instead of tetra.
This change the classpath of the jars which needs to adapted