### PR TITLE
Use runtime scope instead of provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,19 +132,19 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>30.1.1-jre</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-compiler</artifactId>
             <version>7.17.0.Final</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
             <exclusions>
                 <!-- ECJ has been moved to org.eclipse.jdt:ecj -->
                 <exclusion>
@@ -157,37 +157,37 @@
             <groupId>org.mvel</groupId>
             <artifactId>mvel2</artifactId>
             <version>2.2.6.Final</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.11</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>ecj</artifactId>
             <version>3.18.0</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.9.2</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>1.4.19</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
This PR changes the scope of the transitive dependencies to `runtime` instead of `provided`. The current set up in fact has the following downside when developing:

1) the jar created by the `maven-shade-plugin`, which should contain all the dependencies and can be run locally simply with the `java -jar` command, is not working since the `provided` dependencies are not included in it.
2) IDEs that uses the pom.xml (Intellij, VSCode) pick up the wrong dependencies when building the class path to run the application.

This change fixes both problems and facilitates building and running the application locally. 