### PR TITLE
Update the Log4j configuration in the running Log4j contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ drools.log
 subscription-matcher.iml
 .idea/
 .vscode/
+
+# Ignore input/output files from a local run
+/input.json
+/output.json
+/output-all.json
+/log/subscription-matcher.log*
+/message_report.csv
+/subscription_report.csv
+/unmatched_product_report.csv

--- a/pom.xml
+++ b/pom.xml
@@ -87,16 +87,6 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
@@ -125,6 +115,20 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
+        </dependency>
+
+        <!-- Runtime dependencies -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Transitive dependencies overridden to match SLES shipped version -->


### PR DESCRIPTION
This PR fixes the logging configuration. Currently the configuration is not properly updated in all running Log4j context, thus resulting in missing entries in the logs.