### PR TITLE
Fix penalties logging

### DIFF
--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -50,7 +50,7 @@ public class OptaPlanner {
     private static final Logger LOGGER = LogManager.getLogger(OptaPlanner.class);
 
     /** The result. */
-    Assignment result;
+    private final Assignment result;
 
     /**
      * Instantiates an OptaPlanner instance with the specified unsolved problem.

--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -32,7 +32,6 @@ import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.random.RandomType;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
-import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirector;
 
 import java.util.ArrayList;
@@ -117,14 +116,14 @@ public class OptaPlanner {
          * Declare solution and entity classes
          */
         config.setSolutionClass(Assignment.class);
-        config.setEntityClassList(new ArrayList<Class<?>>(){{ add(Match.class); }});
+        config.setEntityClassList(List.of(Match.class));
 
         /*
          * Declare score type and file location
          */
         ScoreDirectorFactoryConfig score = new ScoreDirectorFactoryConfig();
         score.setScoreDefinitionType(ScoreDefinitionType.HARD_SOFT);
-        score.setScoreDrlList(new ArrayList<String>() {{ add("com/suse/matcher/rules/optaplanner/Scores.drl"); }});
+        score.setScoreDrlList(List.of("com/suse/matcher/rules/optaplanner/Scores.drl"));
         config.setScoreDirectorFactoryConfig(score);
 
         /*
@@ -162,10 +161,8 @@ public class OptaPlanner {
         valueSelector.setSelectionOrder(SelectionOrder.ORIGINAL);
         changeMove.setValueSelectorConfig(valueSelector);
 
-        changeMove.setFilterClassList(new ArrayList<Class<? extends SelectionFilter>>() {{
-            add(ConflictMatchMoveFilter.class);
-        }});
-        entityPlacer.setMoveSelectorConfigList(new ArrayList<MoveSelectorConfig>() {{ add(changeMove); }});
+        changeMove.setFilterClassList(List.of(ConflictMatchMoveFilter.class));
+        entityPlacer.setMoveSelectorConfigList(List.of(changeMove));
         constructionHeuristic.setEntityPlacerConfig(entityPlacer);
         config.getPhaseConfigList().add(constructionHeuristic);
 

--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -47,7 +47,7 @@ import java.util.List;
 public class OptaPlanner {
 
     /** Logger instance. */
-    private final Logger logger = LogManager.getLogger(OptaPlanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptaPlanner.class);
 
     /** The result. */
     Assignment result;
@@ -71,13 +71,13 @@ public class OptaPlanner {
         // solve problem
         long start = System.currentTimeMillis();
         solver.solve(unsolved);
-        logger.info("Optimization phase took {}ms", System.currentTimeMillis() - start);
+        LOGGER.info("Optimization phase took {}ms", System.currentTimeMillis() - start);
         result = (Assignment) solver.getBestSolution();
-        logger.info("{} matches confirmed", result.getMatches().stream().filter(m -> m.confirmed).count());
+        LOGGER.info("{} matches confirmed", result.getMatches().stream().filter(m -> m.confirmed).count());
 
         // show Penalty facts generated in Scores.drl using DroolsScoreDirector and re-calculating
         // the score of the best solution because facts generated dynamically are not available outside of this object
-        if (logger.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             DroolsScoreDirector scoreDirector = (DroolsScoreDirector) solver.getScoreDirectorFactory().buildScoreDirector();
             scoreDirector.setWorkingSolution(scoreDirector.cloneSolution(result));
             scoreDirector.calculateScore();
@@ -86,8 +86,8 @@ public class OptaPlanner {
                     .filter(f -> f instanceof OneTwoPenalty)
                     .map(f -> (Penalty)f)
                     .collect(toList());
-            logger.debug("The best solution has " + penalties.size() + " penalties for 1-2 subscriptions.");
-            penalties.forEach(penalty -> logger.debug(penalty.toString()));
+            LOGGER.debug("The best solution has {} penalties for 1-2 subscriptions.", penalties.size());
+            penalties.forEach(penalty -> LOGGER.debug(penalty.toString()));
         }
     }
 

--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -18,7 +18,6 @@ import org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlac
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
@@ -77,17 +76,24 @@ public class OptaPlanner {
         // show Penalty facts generated in Scores.drl using DroolsScoreDirector and re-calculating
         // the score of the best solution because facts generated dynamically are not available outside of this object
         if (LOGGER.isDebugEnabled()) {
-            DroolsScoreDirector<Assignment> scoreDirector = (DroolsScoreDirector<Assignment>) solver.getScoreDirectorFactory().buildScoreDirector();
-            scoreDirector.setWorkingSolution(scoreDirector.cloneSolution(result));
-            scoreDirector.calculateScore();
-            Collection<Penalty> penalties = scoreDirector.getKieSession().getObjects()
-                    .stream()
-                    .filter(f -> f instanceof OneTwoPenalty)
-                    .map(f -> (Penalty)f)
-                    .collect(toList());
-            LOGGER.debug("The best solution has {} penalties for 1-2 subscriptions.", penalties.size());
-            penalties.forEach(penalty -> LOGGER.debug(penalty.toString()));
+            logOneTwoPenalties(solver, result);
         }
+    }
+
+    private static void logOneTwoPenalties(Solver<Assignment> solver, Assignment result) {
+        DroolsScoreDirector<Assignment> scoreDirector = (DroolsScoreDirector<Assignment>) solver.getScoreDirectorFactory().buildScoreDirector();
+
+        scoreDirector.setWorkingSolution(scoreDirector.cloneSolution(result));
+        scoreDirector.calculateScore();
+
+        Collection<Penalty> penalties = scoreDirector.getKieSession().getObjects()
+                .stream()
+                .filter(f -> f instanceof OneTwoPenalty)
+                .map(f -> (Penalty)f)
+                .collect(toList());
+
+        LOGGER.debug("The best solution has {} penalties for 1-2 subscriptions.", penalties.size());
+        penalties.forEach(penalty -> LOGGER.debug(penalty.toString()));
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue with the logging of penalties associated with 1-2 subscriptions. This logging is enabled by default for the `OptaPlanner` class and it involves recomputing the scores. Currently however, this calculation is not performed in the same way as during the actual OptaPlanner execution, thus might lead to a failure under certain scenarios.

This change address the issue and fixes the way the score director is initialized, to make sure is consistent with the one used during the main computation. Moreover, a minor refactoring has been implemented to clean up the code.