### PR TITLE
fix integer overflow which can cause a division by zero error

### DIFF
--- a/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
+++ b/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
@@ -66,7 +66,7 @@ rule "dontExceedSubscriptionCount"
             $penaltyCents : sum($cents)
         )
     then
-        int availableCents = $quantity * 100;
+        int availableCents = ($quantity == Integer.MAX_VALUE) ? Integer.MAX_VALUE : $quantity * 100;
         int totalUsedCents = $penaltyCents.intValue();
         scoreHolder.addHardConstraintMatch(kcontext,
             (availableCents - totalUsedCents) >= 0 ? 0 :


### PR DESCRIPTION
Fix a possible division by zero bug when matching products.
For some subscriptions we set quantity to MAX_VALUE

Issue: https://github.com/SUSE/spacewalk/issues/27233