### PR TITLE
Fix unsupported part number (bsc#1271075)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.suse</groupId>
     <artifactId>subscription-matcher</artifactId>
-    <version>0.45</version>
+    <version>0.46</version>
 
     <name>subscription-matcher</name>
     <description>Expert system to match SUSE subscriptions to a set of systems</description>

--- a/src/main/resources/com/suse/matcher/rules/drools/PartNumbers.drl
+++ b/src/main/resources/com/suse/matcher/rules/drools/PartNumbers.drl
@@ -19972,6 +19972,21 @@ rule "Add subscription data for part number 874-008422"
         };
 end
 
+//SLE SAP X86-64 1-2S/VM PR S 1Y
+rule "Add subscription data for part number 874-008433-C"
+    agenda-group "PartNumbers"
+    when
+        $subscription : Subscription(partNumber == "874-008433-C")
+    then
+        modify($subscription) {
+            policy = Policy.ONE_TWO,
+            supportLevel = "priority",
+            cpus = 2,
+            singleSubscriptionHardBundle = true,
+            stackable = true
+        };
+end
+
 //SLES W/SMLMLM+ X86-64 1-2S/VM ST 1Y
 rule "Add subscription data for part number 874-008517-C"
     agenda-group "PartNumbers"

--- a/src/test/java/com/suse/matcher/MatcherScenariosTest.java
+++ b/src/test/java/com/suse/matcher/MatcherScenariosTest.java
@@ -127,7 +127,7 @@ class MatcherScenariosTest {
                 // Verify the content is the same, apart from the order
                 assertEquals(expectedContent.stream().skip(1).sorted().collect(Collectors.joining("\n")),
                     actualContent.stream().skip(1).sorted().collect(Collectors.joining("\n")),
-                    "Csv content " + csvFile + "do not match");
+                    "Csv content " + csvFile + " do not match");
             } catch(IOException ex) {
                 fail("Unable to verify CSV files");
             }

--- a/src/test/resources/com/suse/matcher/scenarios/50/README.md
+++ b/src/test/resources/com/suse/matcher/scenarios/50/README.md
@@ -1,0 +1,20 @@
+Scenario 50 - Adding part number 874-008433-C
+==============================================================
+
+This scenario tests the fix for bsc#1271075 (https://bugzilla.suse.com/show_bug.cgi?id=1271075)
+
+There is another new SKU showed up missing in subscription matching for one of our customers:
+
+Unsupported part number detected - 874-008433-C
+SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, 1 Year 
+
+The scenario files were originally taken from the user support config,
+and then simplified to check that the actual match works.
+
+It also verifies that 874-008433-C coexists with the closely related part number
+874-006905 (same product family) without either of them producing an "unknown_part_number" message. 
+
+Result
+------
+
+Both 874-008433-C and 874-006905 are correctly detected. Neither triggers "unknown_part_number".

--- a/src/test/resources/com/suse/matcher/scenarios/50/input.json
+++ b/src/test/resources/com/suse/matcher/scenarios/50/input.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-07-23T00:30:00.000+01",
+  "systems": [],
+  "virtualization_groups": [],
+  "products": [],
+  "subscriptions": [
+    {
+      "id": 1,
+      "part_number": "874-006905",
+      "name": "SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, Activation Key",
+      "quantity": 4,
+      "start_date": "2026-07-23T00:30:00.000+01",
+      "end_date": "2027-07-23T00:30:00.000+01",
+      "scc_username": null,
+      "product_ids": []
+    },
+    {
+      "id": 2,
+      "part_number": "874-008433-C",
+      "name": "SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, 1 Year",
+      "quantity": 7,
+      "start_date": "2026-07-23T00:30:00.000+01",
+      "end_date": "2027-07-23T00:30:00.000+01",
+      "scc_username": null,
+      "product_ids": []
+    }
+  ],
+  "pinned_matches": []
+}

--- a/src/test/resources/com/suse/matcher/scenarios/50/message_report.csv
+++ b/src/test/resources/com/suse/matcher/scenarios/50/message_report.csv
@@ -1,0 +1,1 @@
+Message,Additional data key,Additional data value

--- a/src/test/resources/com/suse/matcher/scenarios/50/output.json
+++ b/src/test/resources/com/suse/matcher/scenarios/50/output.json
@@ -1,0 +1,27 @@
+{
+  "timestamp": "2026-07-23T00:30:00.000+01",
+  "matches": [],
+  "subscription_policies": {
+    "1": "one_two",
+    "2": "one_two"
+  },
+  "messages": [],
+  "subscriptions": [
+    {
+      "id": 1,
+      "part_number": "874-006905",
+      "name": "SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, Activation Key",
+      "quantity": 4,
+      "start_date": "2026-07-23T00:30:00.000+01",
+      "end_date": "2027-07-23T00:30:00.000+01"
+    },
+    {
+      "id": 2,
+      "part_number": "874-008433-C",
+      "name": "SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, 1 Year",
+      "quantity": 7,
+      "start_date": "2026-07-23T00:30:00.000+01",
+      "end_date": "2027-07-23T00:30:00.000+01"
+    }
+  ]
+}

--- a/src/test/resources/com/suse/matcher/scenarios/50/subscription_report.csv
+++ b/src/test/resources/com/suse/matcher/scenarios/50/subscription_report.csv
@@ -1,0 +1,3 @@
+Part Number,Description,Policy,Total Quantity,Matched Quantity,Start Date,End Date
+874-006905,"SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, Activation Key",1-2 Sockets or 1-2 Virtual Machines,4,0,2026-07-22,2027-07-22
+874-008433-C,"SUSE Linux Enterprise Server for SAP Applications, x86-64, 1-2 Sockets or 1-2 Virtual Machines, Priority Subscription, 1 Year",1-2 Sockets or 1-2 Virtual Machines,7,0,2026-07-22,2027-07-22

--- a/src/test/resources/com/suse/matcher/scenarios/50/unmatched_product_report.csv
+++ b/src/test/resources/com/suse/matcher/scenarios/50/unmatched_product_report.csv
@@ -1,0 +1,1 @@
+Unmatched Product Name,System Name,System ID,CPUs


### PR DESCRIPTION
This PR adds a missing part number, addressing https://github.com/SUSE/spacewalk/issues/31154 and bumps the version to 0.46